### PR TITLE
Add sf command support for 3.0+ versions

### DIFF
--- a/bin/sf
+++ b/bin/sf
@@ -3,4 +3,12 @@
 DIR=$(basename `pwd` | tr "[:upper:]" "[:lower:]" | tr -cd '[[:alnum:]]')
 CONTAINER="${DIR//-}""_php_1"
 
-docker exec -ti -u www $CONTAINER php -d memory_limit=-1 /var/www/app/console $@
+FILE=app/console
+
+docker exec -u www $CONTAINER ls /var/www/bin/console >> /dev/null 2>&1
+
+if [ $? == 0 ]; then
+    FILE=bin/console
+fi
+
+docker exec -ti -u www $CONTAINER php -d memory_limit=-1 /var/www/$FILE $@


### PR DESCRIPTION
This pull request will add support for Symfony 3.0+ versions, as console file was moved from app folder to bin folder. Also support for older versions (i.e. Symfony 2.8+) is left.
Script checks if bin/console exists and uses it instead of app/console